### PR TITLE
Thêm xác thực 2 bước TOTP

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
         "nodemailer": "^8.0.7",
+        "otplib": "^13.4.0",
         "pg": "^8.13.0",
         "pino": "^9.5.0",
         "pino-pretty": "^11.2.2"
@@ -923,6 +924,67 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@otplib/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw=="
+    },
+    "node_modules/@otplib/hotp": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/hotp/-/hotp-13.4.0.tgz",
+      "integrity": "sha512-MJjE0x06mn2ptymz5qZmQveb+vWFuaIftqE0b5/TZZqUOK7l97cV8lRTmid5BpAQMwJDNLW6RnYxGeCRiNdekw==",
+      "dependencies": {
+        "@otplib/core": "13.4.0",
+        "@otplib/uri": "13.4.0"
+      }
+    },
+    "node_modules/@otplib/plugin-base32-scure": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-base32-scure/-/plugin-base32-scure-13.4.0.tgz",
+      "integrity": "sha512-/t9YWJmMbB8bF5z8mXrBZc2FXBe8B/3hG5FhWr9K8cFwFhyxScbPysmZe8s1UTzSA6N+s8Uv8aIfCtVXPNjJWw==",
+      "dependencies": {
+        "@otplib/core": "13.4.0",
+        "@scure/base": "^2.0.0"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto-noble/-/plugin-crypto-noble-13.4.0.tgz",
+      "integrity": "sha512-KrvE4m7Zv+TT1944HzgqFJWJpKb6AyoxDbvhPStmBqdMlv5Gekb80d66cuFRL08kkPgJ5gXUSb5SFpYeB+bACg==",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1",
+        "@otplib/core": "13.4.0"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@otplib/totp": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/totp/-/totp-13.4.0.tgz",
+      "integrity": "sha512-dK+vl0f0ekzf6mCENRI9AKS2NJUC7OjI3+X8e7QSnhQ2WM7I+i4PGpb3QxKi5hxjTtwVuoZwXR2CFtXdcRtNdQ==",
+      "dependencies": {
+        "@otplib/core": "13.4.0",
+        "@otplib/hotp": "13.4.0",
+        "@otplib/uri": "13.4.0"
+      }
+    },
+    "node_modules/@otplib/uri": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/uri/-/uri-13.4.0.tgz",
+      "integrity": "sha512-x1ozBa5bPbdZCrrTL/HK21qchiK7jYElTu+0ft22abeEhiLYgH1+SIULvOcVk3CK8YwF4kdcidvkq4ciejucJA==",
+      "dependencies": {
+        "@otplib/core": "13.4.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -936,6 +998,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -3776,6 +3846,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/otplib": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-13.4.0.tgz",
+      "integrity": "sha512-RUcYcRMCgRWhUE/XabRppXpUwCwaWBNHe5iPXhdvP8wwDGpGpsIf/kxX/ec3zFsOaM1Oq8lEhUqDwk6W7DHkwg==",
+      "dependencies": {
+        "@otplib/core": "13.4.0",
+        "@otplib/hotp": "13.4.0",
+        "@otplib/plugin-base32-scure": "13.4.0",
+        "@otplib/plugin-crypto-noble": "13.4.0",
+        "@otplib/totp": "13.4.0",
+        "@otplib/uri": "13.4.0"
       }
     },
     "node_modules/p-limit": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^8.0.7",
+    "otplib": "^13.4.0",
     "pg": "^8.13.0",
     "pino": "^9.5.0",
     "pino-pretty": "^11.2.2"

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -2,6 +2,7 @@ const express = require("express")
 const bcrypt = require("bcrypt")
 const jwt = require("jsonwebtoken")
 const crypto = require("crypto")
+const { authenticator } = require("otplib")
 
 const pool = require("../../config/db")
 const { jwt: jwtConfig } = require("../../config")
@@ -181,11 +182,59 @@ router.post("/resend-otp", async (req, res, next) => {
     }
 })
 
+const TWO_FA_PENDING_PURPOSE = "2fa_pending"
+const TWO_FA_PENDING_TTL_SEC = 5 * 60
+const BACKUP_CODE_COUNT = 10
+const BACKUP_CODE_LENGTH = 8
+
+function signTwoFAPendingToken(userId) {
+    return jwt.sign(
+        { id: userId, purpose: TWO_FA_PENDING_PURPOSE },
+        jwtConfig.secret,
+        { expiresIn: TWO_FA_PENDING_TTL_SEC },
+    )
+}
+
+function generateBackupCodes() {
+    const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+    const codes = []
+    for (let i = 0; i < BACKUP_CODE_COUNT; i++) {
+        let c = ""
+        for (let j = 0; j < BACKUP_CODE_LENGTH; j++) {
+            c += chars[crypto.randomInt(0, chars.length)]
+        }
+        codes.push(c)
+    }
+    return codes
+}
+
+async function hashBackupCodes(codes) {
+    return Promise.all(codes.map((c) => bcrypt.hash(c, 10)))
+}
+
+async function issueLoginTokens(user, res) {
+    const { accessToken, refreshToken } = signTokens(user)
+    const tokenHash = crypto.createHash("sha256").update(refreshToken).digest("hex")
+    await pool.query(
+        "INSERT INTO refresh_tokens(user_id, token, expires_at) VALUES($1, $2, NOW() + INTERVAL '30 days')",
+        [user.id, tokenHash],
+    )
+    res.json({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        public_id: user.public_id,
+        email: user.email,
+        full_name: user.full_name,
+        role: user.role,
+        is_verified: user.is_verified,
+    })
+}
+
 router.post("/login", validate(schemas.login), async (req, res, next) => {
     const { email, password } = req.body
     try {
         const result = await pool.query(
-            "SELECT id, public_id, email, full_name, role, password_hash, is_verified FROM users WHERE email=$1",
+            "SELECT id, public_id, email, full_name, role, password_hash, is_verified, two_factor_enabled FROM users WHERE email=$1",
             [email],
         )
         const user = result.rows[0]
@@ -194,22 +243,191 @@ router.post("/login", validate(schemas.login), async (req, res, next) => {
         const valid = await bcrypt.compare(password, user.password_hash)
         if (!valid) return res.status(401).json({ message: "Sai email hoặc mật khẩu" })
 
-        const { accessToken, refreshToken } = signTokens(user)
-        const tokenHash = crypto.createHash("sha256").update(refreshToken).digest("hex")
+        if (user.two_factor_enabled) {
+            return res.json({
+                requires_2fa: true,
+                pending_2fa_token: signTwoFAPendingToken(user.id),
+            })
+        }
+
+        await issueLoginTokens(user, res)
+    } catch (err) {
+        next(err)
+    }
+})
+
+router.post("/2fa/verify", async (req, res, next) => {
+    const { pending_2fa_token, code } = req.body
+    if (!pending_2fa_token || !code) {
+        return res.status(400).json({ message: "Thiếu thông tin xác thực" })
+    }
+    try {
+        let payload
+        try {
+            payload = jwt.verify(pending_2fa_token, jwtConfig.secret)
+        } catch {
+            return res.status(401).json({ message: "Mã xác thực đã hết hạn, vui lòng đăng nhập lại" })
+        }
+        if (payload.purpose !== TWO_FA_PENDING_PURPOSE) {
+            return res.status(401).json({ message: "Token không hợp lệ" })
+        }
+
+        const result = await pool.query(
+            "SELECT id, public_id, email, full_name, role, is_verified, two_factor_enabled, two_factor_secret, two_factor_backup_codes FROM users WHERE id=$1",
+            [payload.id],
+        )
+        const user = result.rows[0]
+        if (!user || !user.two_factor_enabled || !user.two_factor_secret) {
+            return res.status(400).json({ message: "Tài khoản chưa bật 2FA" })
+        }
+
+        const cleanCode = String(code).replace(/[^A-Za-z0-9]/g, "")
+        let ok = false
+        let usedBackup = false
+
+        if (/^\d{6}$/.test(cleanCode)) {
+            ok = authenticator.check(cleanCode, user.two_factor_secret)
+        } else {
+            const codeUpper = cleanCode.toUpperCase()
+            const backupCodes = user.two_factor_backup_codes || []
+            for (let i = 0; i < backupCodes.length; i++) {
+                if (await bcrypt.compare(codeUpper, backupCodes[i])) {
+                    const remaining = backupCodes.filter((_, j) => j !== i)
+                    await pool.query(
+                        "UPDATE users SET two_factor_backup_codes=$1 WHERE id=$2",
+                        [remaining, user.id],
+                    )
+                    ok = true
+                    usedBackup = true
+                    break
+                }
+            }
+        }
+
+        if (!ok) return res.status(400).json({ message: "Mã không đúng" })
+
+        await issueLoginTokens(user, res)
+    } catch (err) {
+        next(err)
+    }
+})
+
+router.post("/2fa/setup", auth, async (req, res, next) => {
+    try {
+        const result = await pool.query("SELECT email, two_factor_enabled FROM users WHERE id=$1", [req.user.id])
+        const user = result.rows[0]
+        if (!user) return res.status(404).json({ message: "Không tìm thấy tài khoản" })
+        if (user.two_factor_enabled) return res.status(400).json({ message: "Tài khoản đã bật 2FA" })
+
+        const secret = authenticator.generateSecret()
+        const otpauthUrl = authenticator.keyuri(user.email, "JobBridge", secret)
+        res.json({ secret, otpauth_url: otpauthUrl })
+    } catch (err) {
+        next(err)
+    }
+})
+
+router.post("/2fa/enable", auth, async (req, res, next) => {
+    const { secret, code } = req.body
+    if (!secret || !code) {
+        return res.status(400).json({ message: "Thiếu thông tin" })
+    }
+    if (!/^\d{6}$/.test(String(code))) {
+        return res.status(400).json({ message: "Mã phải là 6 chữ số" })
+    }
+    try {
+        const result = await pool.query("SELECT two_factor_enabled FROM users WHERE id=$1", [req.user.id])
+        const user = result.rows[0]
+        if (!user) return res.status(404).json({ message: "Không tìm thấy tài khoản" })
+        if (user.two_factor_enabled) return res.status(400).json({ message: "Tài khoản đã bật 2FA" })
+
+        const ok = authenticator.check(String(code), secret)
+        if (!ok) return res.status(400).json({ message: "Mã không đúng, vui lòng thử lại" })
+
+        const codes = generateBackupCodes()
+        const codeHashes = await hashBackupCodes(codes)
 
         await pool.query(
-            "INSERT INTO refresh_tokens(user_id, token, expires_at) VALUES($1, $2, NOW() + INTERVAL '30 days')",
-            [user.id, tokenHash],
+            "UPDATE users SET two_factor_enabled=true, two_factor_secret=$1, two_factor_backup_codes=$2 WHERE id=$3",
+            [secret, codeHashes, req.user.id],
         )
 
+        res.json({ success: true, backup_codes: codes })
+    } catch (err) {
+        next(err)
+    }
+})
+
+router.post("/2fa/disable", auth, async (req, res, next) => {
+    const { password, code } = req.body
+    if (!password || !code) {
+        return res.status(400).json({ message: "Vui lòng nhập mật khẩu và mã xác thực" })
+    }
+    try {
+        const result = await pool.query(
+            "SELECT password_hash, two_factor_enabled, two_factor_secret FROM users WHERE id=$1",
+            [req.user.id],
+        )
+        const user = result.rows[0]
+        if (!user) return res.status(404).json({ message: "Không tìm thấy tài khoản" })
+        if (!user.two_factor_enabled) return res.status(400).json({ message: "Tài khoản chưa bật 2FA" })
+
+        const passwordOk = await bcrypt.compare(password, user.password_hash)
+        if (!passwordOk) return res.status(400).json({ message: "Mật khẩu không đúng" })
+
+        const codeOk = /^\d{6}$/.test(String(code)) && authenticator.check(String(code), user.two_factor_secret)
+        if (!codeOk) return res.status(400).json({ message: "Mã 2FA không đúng" })
+
+        await pool.query(
+            "UPDATE users SET two_factor_enabled=false, two_factor_secret=NULL, two_factor_backup_codes=NULL WHERE id=$1",
+            [req.user.id],
+        )
+
+        res.json({ success: true })
+    } catch (err) {
+        next(err)
+    }
+})
+
+router.post("/2fa/regenerate-backup-codes", auth, async (req, res, next) => {
+    const { code } = req.body
+    if (!code) return res.status(400).json({ message: "Vui lòng nhập mã 2FA" })
+    try {
+        const result = await pool.query(
+            "SELECT two_factor_enabled, two_factor_secret FROM users WHERE id=$1",
+            [req.user.id],
+        )
+        const user = result.rows[0]
+        if (!user || !user.two_factor_enabled) {
+            return res.status(400).json({ message: "Tài khoản chưa bật 2FA" })
+        }
+
+        const ok = /^\d{6}$/.test(String(code)) && authenticator.check(String(code), user.two_factor_secret)
+        if (!ok) return res.status(400).json({ message: "Mã không đúng" })
+
+        const codes = generateBackupCodes()
+        const codeHashes = await hashBackupCodes(codes)
+        await pool.query(
+            "UPDATE users SET two_factor_backup_codes=$1 WHERE id=$2",
+            [codeHashes, req.user.id],
+        )
+
+        res.json({ backup_codes: codes })
+    } catch (err) {
+        next(err)
+    }
+})
+
+router.get("/2fa/status", auth, async (req, res, next) => {
+    try {
+        const result = await pool.query(
+            "SELECT two_factor_enabled, COALESCE(array_length(two_factor_backup_codes, 1), 0) AS backup_remaining FROM users WHERE id=$1",
+            [req.user.id],
+        )
+        const user = result.rows[0]
         res.json({
-            access_token: accessToken,
-            refresh_token: refreshToken,
-            public_id: user.public_id,
-            email: user.email,
-            full_name: user.full_name,
-            role: user.role,
-            is_verified: user.is_verified,
+            enabled: !!user?.two_factor_enabled,
+            backup_remaining: Number(user?.backup_remaining || 0),
         })
     } catch (err) {
         next(err)
@@ -375,7 +593,7 @@ router.delete("/sessions", auth, async (req, res, next) => {
 router.get("/me", auth, async (req, res, next) => {
     try {
         const result = await pool.query(
-            "SELECT id, public_id, email, full_name, phone, date_of_birth, gender, address, bio, role, is_verified, created_at FROM users WHERE id=$1",
+            "SELECT id, public_id, email, full_name, phone, date_of_birth, gender, address, bio, role, is_verified, two_factor_enabled, created_at FROM users WHERE id=$1",
             [req.user.id],
         )
         if (result.rows.length === 0) return res.status(404).json({ message: "Not found" })

--- a/db/init.sql
+++ b/db/init.sql
@@ -12,6 +12,9 @@ CREATE TABLE users (
     address jsonb,
     bio text,
     notification_settings jsonb,
+    two_factor_enabled boolean DEFAULT false,
+    two_factor_secret text,
+    two_factor_backup_codes text[],
     role text DEFAULT 'job_seeker' NOT NULL CHECK (role IN ('job_seeker', 'recruiter', 'admin')),
     is_verified boolean DEFAULT false,
     created_at timestamp DEFAULT CURRENT_TIMESTAMP

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "html2canvas-pro": "^2.0.2",
         "html2pdf.js": "^0.14.0",
         "jspdf": "^4.2.1",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.30.3"
@@ -2284,6 +2285,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/raf": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "html2canvas-pro": "^2.0.2",
     "html2pdf.js": "^0.14.0",
     "jspdf": "^4.2.1",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^6.30.3"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import ToastContainer from "./components/common/Toast"
 
 import Home from "./pages/Home"
 import Login from "./pages/Login"
+import Login2FA from "./pages/Login2FA"
 import Register from "./pages/Register"
 import Onboarding from "./pages/Onboarding"
 import VerifyEmail from "./pages/VerifyEmail"
@@ -82,6 +83,7 @@ export default function App() {
                         <Route path="cv-templates" element={<CVTemplates />} />
                         <Route path="cv-builder" element={<CVBuilder />} />
                         <Route path="login" element={<GuestOnly><Login /></GuestOnly>} />
+                        <Route path="login/2fa" element={<GuestOnly><Login2FA /></GuestOnly>} />
                         <Route path="register" element={<GuestOnly><Register /></GuestOnly>} />
                         <Route path="onboarding" element={<Onboarding />} />
                         <Route path="verify-email" element={<VerifyEmail />} />

--- a/frontend/src/components/security/BackupCodes.css
+++ b/frontend/src/components/security/BackupCodes.css
@@ -1,0 +1,48 @@
+.backup-codes {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.backup-codes-warning {
+    background: #fef3c7;
+    border: 1px solid #fde68a;
+    border-radius: 8px;
+    padding: 12px 14px;
+    color: #92400e;
+    font-size: 12.5px;
+    line-height: 1.55;
+}
+
+.backup-codes-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+    padding: 14px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+}
+
+.backup-codes-grid code {
+    font-family: 'Courier New', monospace;
+    font-size: 14px;
+    font-weight: 600;
+    color: #0f172a;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 8px 10px;
+    text-align: center;
+    user-select: all;
+    letter-spacing: 1.5px;
+}
+
+.backup-codes-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.backup-codes-actions .btn {
+    flex: 1;
+}

--- a/frontend/src/components/security/BackupCodes.jsx
+++ b/frontend/src/components/security/BackupCodes.jsx
@@ -1,0 +1,47 @@
+import { useToast } from '../../hooks/useToast'
+import './BackupCodes.css'
+
+export default function BackupCodes({ codes }) {
+    const { addToast } = useToast()
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(codes.join('\n'))
+            addToast('Đã sao chép tất cả mã', 'success')
+        } catch {
+            addToast('Không sao chép được', 'error')
+        }
+    }
+
+    const handleDownload = () => {
+        const blob = new Blob(
+            [`JobBridge — Mã khôi phục 2FA\nNgày tạo: ${new Date().toLocaleString('vi-VN')}\n\n${codes.join('\n')}\n\nMỗi mã chỉ dùng được 1 lần. Lưu ở nơi an toàn.\n`],
+            { type: 'text/plain' },
+        )
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = 'jobbridge-backup-codes.txt'
+        a.click()
+        URL.revokeObjectURL(url)
+    }
+
+    return (
+        <div className="backup-codes">
+            <div className="backup-codes-warning">
+                ⚠ Lưu ngay 10 mã khôi phục dưới đây. Mỗi mã chỉ dùng được 1 lần khi bạn không có app authenticator. Sau khi đóng cửa sổ bạn sẽ không xem lại được.
+            </div>
+
+            <div className="backup-codes-grid">
+                {codes.map((c, i) => (
+                    <code key={i}>{c}</code>
+                ))}
+            </div>
+
+            <div className="backup-codes-actions">
+                <button type="button" className="btn btn-outline" onClick={handleCopy}>Sao chép</button>
+                <button type="button" className="btn btn-outline" onClick={handleDownload}>Tải file .txt</button>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/components/security/Setup2FAModal.css
+++ b/frontend/src/components/security/Setup2FAModal.css
@@ -1,0 +1,153 @@
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 16px;
+    overflow-y: auto;
+}
+
+.modal-card {
+    background: #fff;
+    border-radius: 14px;
+    width: min(480px, 100%);
+    max-height: calc(100vh - 48px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.modal-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 22px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.modal-head h2 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.modal-close {
+    width: 30px;
+    height: 30px;
+    border: none;
+    background: transparent;
+    color: #64748b;
+    font-size: 15px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.modal-close:hover {
+    background: #f1f5f9;
+}
+
+.modal-body {
+    padding: 20px 22px;
+    overflow-y: auto;
+}
+
+.modal-loading {
+    text-align: center;
+    color: #64748b;
+    padding: 30px;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 18px;
+    padding-top: 16px;
+    border-top: 1px solid #f1f5f9;
+}
+
+.setup-steps {
+    margin: 0 0 16px;
+    padding-left: 18px;
+    font-size: 13px;
+    color: #475569;
+    line-height: 1.6;
+}
+
+.setup-steps li {
+    margin-bottom: 4px;
+}
+
+.setup-qr-box {
+    display: flex;
+    justify-content: center;
+    padding: 14px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    margin-bottom: 14px;
+}
+
+.setup-secret {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 14px;
+}
+
+.setup-secret label {
+    font-size: 12px;
+    color: #64748b;
+}
+
+.setup-secret code {
+    background: #f1f5f9;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-family: 'Courier New', monospace;
+    font-size: 13px;
+    color: #0f172a;
+    user-select: all;
+    word-break: break-all;
+}
+
+.setup-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+
+.setup-field label {
+    font-size: 13px;
+    font-weight: 500;
+    color: #374151;
+}
+
+.setup-field input {
+    padding: 10px 14px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    font-size: 18px;
+    text-align: center;
+    letter-spacing: 6px;
+    font-weight: 600;
+    color: #0f172a;
+    outline: none;
+    transition: border-color 0.15s;
+    font-family: 'Courier New', monospace;
+}
+
+.setup-field input:focus {
+    border-color: #2563eb;
+}
+
+.setup-error {
+    margin-top: 10px;
+    color: #dc2626;
+    font-size: 12.5px;
+}

--- a/frontend/src/components/security/Setup2FAModal.jsx
+++ b/frontend/src/components/security/Setup2FAModal.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { useToast } from '../../hooks/useToast'
+import { auth as authApi } from '../../services/api'
+import BackupCodes from './BackupCodes'
+import './Setup2FAModal.css'
+
+export default function Setup2FAModal({ open, onClose, onSuccess }) {
+    const { addToast } = useToast()
+    const [step, setStep] = useState('qr')
+    const [secret, setSecret] = useState('')
+    const [otpauthUrl, setOtpauthUrl] = useState('')
+    const [code, setCode] = useState('')
+    const [backupCodes, setBackupCodes] = useState([])
+    const [loading, setLoading] = useState(false)
+    const [verifying, setVerifying] = useState(false)
+    const [error, setError] = useState('')
+
+    useEffect(() => {
+        if (!open) return
+        setStep('qr')
+        setCode('')
+        setBackupCodes([])
+        setError('')
+        setLoading(true)
+        authApi.twoFA.setup()
+            .then((data) => {
+                setSecret(data.secret)
+                setOtpauthUrl(data.otpauth_url)
+            })
+            .catch((err) => setError(err.message || 'Không khởi tạo được 2FA'))
+            .finally(() => setLoading(false))
+    }, [open])
+
+    useEffect(() => {
+        if (!open) return
+        const handler = (e) => { if (e.key === 'Escape' && step !== 'codes') onClose() }
+        document.addEventListener('keydown', handler)
+        return () => document.removeEventListener('keydown', handler)
+    }, [open, onClose, step])
+
+    if (!open) return null
+
+    const handleVerify = async (e) => {
+        e.preventDefault()
+        if (!/^\d{6}$/.test(code)) {
+            setError('Vui lòng nhập đúng 6 chữ số')
+            return
+        }
+        setVerifying(true)
+        setError('')
+        try {
+            const data = await authApi.twoFA.enable(secret, code)
+            setBackupCodes(data.backup_codes)
+            setStep('codes')
+            addToast('Đã kích hoạt xác thực 2 bước', 'success')
+        } catch (err) {
+            setError(err.message || 'Mã không đúng')
+        } finally {
+            setVerifying(false)
+        }
+    }
+
+    const handleFinish = () => {
+        onSuccess?.()
+        onClose()
+    }
+
+    return (
+        <div className="modal-backdrop" onClick={() => step !== 'codes' && onClose()}>
+            <div className="modal-card" onClick={(e) => e.stopPropagation()}>
+                <header className="modal-head">
+                    <h2>Kích hoạt xác thực 2 bước</h2>
+                    {step !== 'codes' && (
+                        <button type="button" className="modal-close" onClick={onClose} aria-label="Đóng">✕</button>
+                    )}
+                </header>
+
+                {loading ? (
+                    <div className="modal-body modal-loading">Đang tạo mã...</div>
+                ) : step === 'qr' ? (
+                    <form className="modal-body" onSubmit={handleVerify}>
+                        <ol className="setup-steps">
+                            <li>Mở app authenticator (Google Authenticator, Microsoft Authenticator, Authy...).</li>
+                            <li>Quét mã QR bên dưới hoặc nhập tay mã bí mật.</li>
+                            <li>Nhập 6 số hiện trên app để xác nhận.</li>
+                        </ol>
+
+                        <div className="setup-qr-box">
+                            {otpauthUrl && (
+                                <QRCodeSVG value={otpauthUrl} size={180} bgColor="#fff" fgColor="#0f172a" level="M" />
+                            )}
+                        </div>
+
+                        <div className="setup-secret">
+                            <label>Mã bí mật</label>
+                            <code>{secret}</code>
+                        </div>
+
+                        <div className="setup-field">
+                            <label htmlFor="totp-code">Mã từ app</label>
+                            <input
+                                id="totp-code"
+                                type="text"
+                                inputMode="numeric"
+                                maxLength={6}
+                                placeholder="123456"
+                                value={code}
+                                onChange={(e) => { setCode(e.target.value.replace(/\D/g, '')); setError('') }}
+                                autoComplete="one-time-code"
+                                autoFocus
+                            />
+                        </div>
+
+                        {error && <div className="setup-error">{error}</div>}
+
+                        <div className="modal-actions">
+                            <button type="button" className="btn btn-outline" onClick={onClose} disabled={verifying}>Hủy</button>
+                            <button type="submit" className="btn btn-primary" disabled={verifying || code.length !== 6}>
+                                {verifying ? 'Đang xác minh...' : 'Xác nhận'}
+                            </button>
+                        </div>
+                    </form>
+                ) : (
+                    <div className="modal-body">
+                        <BackupCodes codes={backupCodes} />
+                        <div className="modal-actions">
+                            <button type="button" className="btn btn-primary" onClick={handleFinish}>
+                                Tôi đã lưu, hoàn tất
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -44,6 +44,21 @@ export function AuthProvider({ children }) {
 
   const login = useCallback(async (email, password) => {
     const data = await auth.login(email, password)
+    if (data.requires_2fa) {
+      return { requires_2fa: true, pending_2fa_token: data.pending_2fa_token }
+    }
+    token.set(data.access_token, data.refresh_token)
+    return persist({
+      public_id: data.public_id || null,
+      email: data.email,
+      full_name: data.full_name || '',
+      role: data.role,
+      is_verified: !!data.is_verified,
+    })
+  }, [persist])
+
+  const completeTwoFA = useCallback(async (pending_token, code) => {
+    const data = await auth.twoFA.verify(pending_token, code)
     token.set(data.access_token, data.refresh_token)
     return persist({
       public_id: data.public_id || null,
@@ -139,6 +154,7 @@ export function AuthProvider({ children }) {
       isAdmin,
       isVerified,
       login,
+      completeTwoFA,
       register,
       verifyEmail,
       resendOtp,

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -49,6 +49,15 @@ export default function Login() {
     setApiError('')
     try {
       const userData = await login(formData.email, formData.password)
+      if (userData.requires_2fa) {
+        navigate('/login/2fa', {
+          state: {
+            pending_2fa_token: userData.pending_2fa_token,
+            redirectTo,
+          },
+        })
+        return
+      }
       addToast('Đăng nhập thành công', 'success')
       if (userData.role === 'admin') {
         navigate('/admin')

--- a/frontend/src/pages/Login2FA.jsx
+++ b/frontend/src/pages/Login2FA.jsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useLocation, Link } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import { useToast } from '../hooks/useToast'
+import './Login.css'
+
+export default function Login2FA() {
+    const navigate = useNavigate()
+    const location = useLocation()
+    const { completeTwoFA } = useAuth()
+    const { addToast } = useToast()
+
+    const pendingToken = location.state?.pending_2fa_token
+    const redirectTo = location.state?.redirectTo || '/'
+
+    const [code, setCode] = useState('')
+    const [useBackup, setUseBackup] = useState(false)
+    const [loading, setLoading] = useState(false)
+    const [apiError, setApiError] = useState('')
+
+    useEffect(() => {
+        if (!pendingToken) {
+            navigate('/login', { replace: true })
+        }
+    }, [pendingToken, navigate])
+
+    const handleSubmit = async (e) => {
+        e.preventDefault()
+        const cleanCode = code.replace(/[\s-]/g, '')
+        if (!cleanCode) {
+            setApiError('Vui lòng nhập mã xác thực')
+            return
+        }
+        if (!useBackup && !/^\d{6}$/.test(cleanCode)) {
+            setApiError('Mã xác thực phải là 6 chữ số')
+            return
+        }
+        setLoading(true)
+        setApiError('')
+        try {
+            const userData = await completeTwoFA(pendingToken, cleanCode)
+            addToast('Đăng nhập thành công', 'success')
+            if (userData.role === 'admin') navigate('/admin')
+            else navigate(redirectTo)
+        } catch (err) {
+            setApiError(err.message || 'Mã không đúng')
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    if (!pendingToken) return null
+
+    return (
+        <div className="auth-page">
+            <div className="auth-card">
+                <div className="auth-header">
+                    <h1 className="auth-title">Xác thực 2 bước</h1>
+                    <p className="auth-subtitle">
+                        {useBackup
+                            ? 'Nhập một trong các mã khôi phục bạn đã lưu khi kích hoạt 2FA.'
+                            : 'Mở app authenticator và nhập 6 số đang hiển thị.'}
+                    </p>
+                </div>
+
+                <form className="auth-form" onSubmit={handleSubmit} noValidate>
+                    <div className="form-group">
+                        <label htmlFor="code">{useBackup ? 'Mã khôi phục' : 'Mã 6 số'}</label>
+                        <input
+                            type="text"
+                            id="code"
+                            inputMode={useBackup ? 'text' : 'numeric'}
+                            maxLength={useBackup ? 12 : 6}
+                            placeholder={useBackup ? 'Vd: A4B7K2P9' : '123456'}
+                            value={code}
+                            onChange={(e) => {
+                                const v = useBackup
+                                    ? e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '')
+                                    : e.target.value.replace(/\D/g, '')
+                                setCode(v)
+                                if (apiError) setApiError('')
+                            }}
+                            autoComplete="one-time-code"
+                            autoFocus
+                            style={{ letterSpacing: useBackup ? '2px' : '6px', textAlign: 'center', fontFamily: 'monospace', fontSize: 18, fontWeight: 600 }}
+                        />
+                    </div>
+
+                    {apiError && <div className="auth-api-error">{apiError}</div>}
+
+                    <button type="submit" className="btn btn-primary auth-submit" disabled={loading}>
+                        {loading ? 'Đang xác minh...' : 'Xác minh'}
+                    </button>
+
+                    <button
+                        type="button"
+                        className="btn-link"
+                        onClick={() => { setUseBackup((v) => !v); setCode(''); setApiError('') }}
+                        style={{ background: 'none', border: 'none', color: '#2563eb', cursor: 'pointer', fontSize: 13, marginTop: 8 }}
+                    >
+                        {useBackup ? 'Dùng mã từ app authenticator' : 'Dùng mã khôi phục thay'}
+                    </button>
+                </form>
+
+                <p className="auth-footer">
+                    Sai tài khoản? <Link to="/login">Đăng nhập lại</Link>
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/pages/dashboard/SecuritySettings.css
+++ b/frontend/src/pages/dashboard/SecuritySettings.css
@@ -61,6 +61,11 @@
     color: #b45309;
 }
 
+.security-badge-success {
+    background: #d1fae5;
+    color: #047857;
+}
+
 .security-form {
     margin-top: 18px;
     padding-top: 18px;

--- a/frontend/src/pages/dashboard/SecuritySettings.jsx
+++ b/frontend/src/pages/dashboard/SecuritySettings.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useToast } from '../../hooks/useToast'
 import { auth as authApi, token as tokenStore } from '../../services/api'
+import Setup2FAModal from '../../components/security/Setup2FAModal'
 import './SecuritySettings.css'
 
 const PASSWORD_RULES = [
@@ -40,6 +41,50 @@ export default function SecuritySettings() {
     const [sessions, setSessions] = useState([])
     const [sessionsLoading, setSessionsLoading] = useState(true)
     const [revoking, setRevoking] = useState(false)
+
+    const [twoFAStatus, setTwoFAStatus] = useState({ enabled: false, backup_remaining: 0 })
+    const [twoFALoading, setTwoFALoading] = useState(true)
+    const [setupOpen, setSetupOpen] = useState(false)
+    const [disableOpen, setDisableOpen] = useState(false)
+    const [disablePassword, setDisablePassword] = useState('')
+    const [disableCode, setDisableCode] = useState('')
+    const [disableBusy, setDisableBusy] = useState(false)
+    const [disableErr, setDisableErr] = useState('')
+
+    const loadTwoFAStatus = async () => {
+        try {
+            const data = await authApi.twoFA.status()
+            setTwoFAStatus(data)
+        } catch {
+            setTwoFAStatus({ enabled: false, backup_remaining: 0 })
+        } finally {
+            setTwoFALoading(false)
+        }
+    }
+
+    useEffect(() => { loadTwoFAStatus() }, [])
+
+    const handleDisable2FA = async (e) => {
+        e.preventDefault()
+        if (!disablePassword || !/^\d{6}$/.test(disableCode)) {
+            setDisableErr('Vui lòng nhập đầy đủ mật khẩu và 6 chữ số mã 2FA')
+            return
+        }
+        setDisableBusy(true)
+        setDisableErr('')
+        try {
+            await authApi.twoFA.disable(disablePassword, disableCode)
+            addToast('Đã tắt xác thực 2 bước', 'info')
+            setDisableOpen(false)
+            setDisablePassword('')
+            setDisableCode('')
+            loadTwoFAStatus()
+        } catch (err) {
+            setDisableErr(err.message || 'Tắt 2FA thất bại')
+        } finally {
+            setDisableBusy(false)
+        }
+    }
 
     const passwordChecks = useMemo(
         () => PASSWORD_RULES.map((r) => ({ ...r, ok: r.test(pwForm.next) })),
@@ -223,17 +268,78 @@ export default function SecuritySettings() {
                 <div className="security-card-head">
                     <div>
                         <h2>Xác minh 2 bước (2FA)</h2>
-                        <p>Tăng cường bảo mật với mã xác thực một lần từ ứng dụng.</p>
+                        <p>Bảo vệ tài khoản bằng mã xác thực một lần từ app như Google Authenticator, Authy.</p>
                     </div>
-                    <span className="security-badge security-badge-warning">Chưa kích hoạt</span>
+                    {twoFALoading ? (
+                        <span className="security-hint">Đang tải...</span>
+                    ) : twoFAStatus.enabled ? (
+                        <span className="security-badge security-badge-success">Đã kích hoạt</span>
+                    ) : (
+                        <span className="security-badge security-badge-warning">Chưa kích hoạt</span>
+                    )}
                 </div>
-                <div className="security-2fa-body">
-                    <button type="button" className="btn btn-primary" disabled>
-                        Kích hoạt 2FA
-                    </button>
-                    <span className="security-hint">Tính năng sắp ra mắt</span>
-                </div>
+                {!twoFALoading && (
+                    <div className="security-2fa-body">
+                        {twoFAStatus.enabled ? (
+                            <>
+                                <span className="security-hint">Còn {twoFAStatus.backup_remaining} mã khôi phục.</span>
+                                <button type="button" className="btn btn-outline btn-danger" onClick={() => setDisableOpen(true)}>
+                                    Tắt 2FA
+                                </button>
+                            </>
+                        ) : (
+                            <button type="button" className="btn btn-primary" onClick={() => setSetupOpen(true)}>
+                                Kích hoạt 2FA
+                            </button>
+                        )}
+                    </div>
+                )}
+
+                {disableOpen && (
+                    <form className="security-form" onSubmit={handleDisable2FA} noValidate>
+                        <div className="security-field">
+                            <label>Mật khẩu hiện tại</label>
+                            <input
+                                type="password"
+                                value={disablePassword}
+                                onChange={(e) => { setDisablePassword(e.target.value); setDisableErr('') }}
+                                autoComplete="current-password"
+                            />
+                        </div>
+                        <div className="security-field">
+                            <label>Mã 2FA (6 chữ số)</label>
+                            <input
+                                type="text"
+                                inputMode="numeric"
+                                maxLength={6}
+                                value={disableCode}
+                                onChange={(e) => { setDisableCode(e.target.value.replace(/\D/g, '')); setDisableErr('') }}
+                                autoComplete="one-time-code"
+                            />
+                        </div>
+                        {disableErr && <div className="security-api-error">{disableErr}</div>}
+                        <div className="security-form-actions">
+                            <button
+                                type="button"
+                                className="btn btn-outline"
+                                onClick={() => { setDisableOpen(false); setDisableErr(''); setDisablePassword(''); setDisableCode('') }}
+                                disabled={disableBusy}
+                            >
+                                Hủy
+                            </button>
+                            <button type="submit" className="btn btn-primary btn-danger" disabled={disableBusy}>
+                                {disableBusy ? 'Đang xử lý...' : 'Xác nhận tắt 2FA'}
+                            </button>
+                        </div>
+                    </form>
+                )}
             </section>
+
+            <Setup2FAModal
+                open={setupOpen}
+                onClose={() => setSetupOpen(false)}
+                onSuccess={loadTwoFAStatus}
+            />
 
             <section id="section-sessions" className="security-card">
                 <div className="security-card-head">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -116,6 +116,26 @@ export const auth = {
     method: "DELETE",
     body: JSON.stringify({ current_refresh_token }),
   }),
+  twoFA: {
+    status: () => apiFetch("/auth/2fa/status"),
+    setup: () => apiFetch("/auth/2fa/setup", { method: "POST" }),
+    enable: (secret, code) => apiFetch("/auth/2fa/enable", {
+      method: "POST",
+      body: JSON.stringify({ secret, code }),
+    }),
+    disable: (password, code) => apiFetch("/auth/2fa/disable", {
+      method: "POST",
+      body: JSON.stringify({ password, code }),
+    }),
+    regenerateBackupCodes: (code) => apiFetch("/auth/2fa/regenerate-backup-codes", {
+      method: "POST",
+      body: JSON.stringify({ code }),
+    }),
+    verify: (pending_2fa_token, code) => apiFetch("/auth/2fa/verify", {
+      method: "POST",
+      body: JSON.stringify({ pending_2fa_token, code }),
+    }),
+  },
   getNotificationSettings: () => apiFetch("/auth/notification-settings"),
   updateNotificationSettings: (payload) => apiFetch("/auth/notification-settings", {
     method: "PATCH",


### PR DESCRIPTION
## Mục tiêu

Cho user bật xác thực 2 yếu tố qua TOTP (tương thích Google Authenticator, Microsoft Authenticator, Authy). Khi đã bật, đăng nhập sẽ yêu cầu thêm mã 6 số sau khi xác minh password.

## Thay đổi chính

### Backend

- Migration: thêm cột `two_factor_enabled`, `two_factor_secret`, `two_factor_backup_codes` (text[]) vào `users`
- Dependency: `otplib`
- Endpoints mới (auth required):
  - `GET /auth/2fa/status` — trả enabled + số backup codes còn lại
  - `POST /auth/2fa/setup` — gen secret tạm + otpauth URL (chưa save)
  - `POST /auth/2fa/enable` — verify code lần đầu, lưu secret, trả 10 backup codes plaintext (1 lần)
  - `POST /auth/2fa/disable` — verify password + code → tắt
  - `POST /auth/2fa/regenerate-backup-codes` — verify code → tạo lại 10 codes
  - `POST /auth/2fa/verify` — verify pending_2fa_token + code → trả access/refresh
- Modify `POST /auth/login`: nếu user đã bật 2FA, KHÔNG trả token mà trả `{requires_2fa: true, pending_2fa_token: <JWT 5 phút>}`
- Backup codes: 10 codes 8 ký tự alphanumeric (tránh O, 0, 1, I), bcrypt hash, dùng 1 lần
- Pending token: JWT TTL 5 phút, purpose `2fa_pending`

### Frontend

- Dependency: `qrcode.react`
- Components mới:
  - `Setup2FAModal` — flow scan QR → verify → hiển thị backup codes
  - `BackupCodes` — list 10 codes + nút Sao chép / Tải file .txt
- Page mới: `/login/2fa` (`Login2FA.jsx`) — input 6 số TOTP hoặc 8 ký tự backup code, có toggle giữa 2 mode
- Update `SecuritySettings`:
  - Section 2FA: badge "Đã kích hoạt" / "Chưa kích hoạt", nút Kích hoạt → mở modal, nút Tắt 2FA → form yêu cầu password + code
- Update `Login.jsx`: handle `requires_2fa` response → navigate `/login/2fa` với pending token
- Update `useAuth`: thêm method `completeTwoFA(token, code)` ký token sau khi verify

## Test plan

- [ ] User chưa bật 2FA: đăng nhập như cũ
- [ ] Bật 2FA: scan QR bằng Google Authenticator → nhập code → nhận 10 backup codes
- [ ] Đăng nhập sau khi bật: nhập email/pass → tự chuyển `/login/2fa` → nhập 6 số → vào dashboard
- [ ] Đăng nhập với backup code: toggle "Dùng mã khôi phục" → nhập 1 code → OK, code đó không dùng lại được
- [ ] Tắt 2FA: nhập password + code → secret và backup codes về NULL
- [ ] Pending 2FA token hết hạn sau 5 phút → buộc đăng nhập lại

## Out of scope

- Encrypt 2FA secret trong DB (dev phase plaintext)
- Recovery qua email
- WebAuthn / hardware key
- Remember this device
- Rate limit verify (issue khác)